### PR TITLE
Fixing git branch being displayed in editor

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -10,3 +10,5 @@
 	process = git-lfs filter-process
 	required = true
 	clean = git-lfs clean -- %f
+[pager]
+	branch = false


### PR DESCRIPTION
Storing the result of `git config --global pager.branch false` as my global config of git.