### PR TITLE
feat: manage global Claude Code agent instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,7 @@
+# Global notes for agents
+
+## Google accounts (Gmail, Drive, Docs, Sheets, Calendar)
+
+Use the `gws` CLI through the `gwsa` wrapper — never bare `gws` for account-specific work. Accounts are defined as per-machine profiles: run `gwsa list` to see them, and read `profiles.local.csv` inside the `gws-multi-account` skill (linked in `~/.claude/skills/`) for the profile → email mapping, including send-as aliases. Load that skill for commands, login scopes, and troubleshooting.
+
+If `gwsa` or the skill is missing on this machine, set them up from <https://github.com/hervenivon/skills> (`skills/gws-multi-account/scripts/bootstrap.sh`), then restore credentials by copying `~/.config/gws-accounts/` from an authenticated machine.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ With iTerm2 comes [shell-integration](https://iterm2.com/documentation-shell-int
 
 Some tools require further configuration, like Clean My Mac X - which requires a license.
 
+#### AI agents (Claude Code & friends)
+
+`bootstrap.sh --link` symlinks `.claude/CLAUDE.md` to `~/.claude/CLAUDE.md` — global instructions every Claude Code session loads (multi-account Google Workspace CLI usage, etc.). Reusable agent skills live in a dedicated repo: [hervenivon/skills](https://github.com/hervenivon/skills); follow its README to install them on a new machine.
+
 ## Terminal results
 
 <img src="./imgs/result.png" width="720px"/>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -335,6 +335,11 @@ link_ohmyzsh () {
   ln -sf `pwd`/vendors/oh-my-zsh ~/.oh-my-zsh
 }
 
+link_claude () {
+  mkdir -p $HOME/.claude
+  ln -sf `pwd`/.claude/CLAUDE.md $HOME/.claude/CLAUDE.md
+}
+
 _execution() {
   _debug printf ">> Performing operation...\\n"
 
@@ -362,6 +367,7 @@ _execution() {
     backup_file $HOME/.gitconfig
     backup_file $HOME/.gitignore_global
     backup_file $HOME/.nvmrc
+    backup_file $HOME/.claude/CLAUDE.md
   fi
 
   if ((_OPTION_LINK))
@@ -380,6 +386,7 @@ _execution() {
     link_jq
     link_git_config
     link_and_setup_nvm
+    link_claude
   fi
 }
 


### PR DESCRIPTION
## What

- Adds `.claude/CLAUDE.md` — global instructions loaded by every Claude Code session (and readable by other agent harnesses): how to use the multi-account Google Workspace CLI (`gwsa` profiles for the personal/scenario/cofactory accounts, send-as alias for scenario.com).
- Adds a `link_claude` step to `bootstrap.sh` (`--link`), symlinking it to `~/.claude/CLAUDE.md` like the other dotfiles, plus a backup entry.
- README: new *AI agents* section pointing to [hervenivon/skills](https://github.com/hervenivon/skills) where the actual agent skills live.

## Why

Makes every AI agent on a freshly bootstrapped Mac aware of the Google multi-account setup without having to rediscover it. Pairs with the `gws-multi-account` skill repo (its `bootstrap.sh` installs the `gwsa` wrapper and skill symlinks; credentials are restored by copying `~/.config/gws-accounts/`).

## Test

- `bash -n bootstrap.sh` passes.
- `link_claude` exercised against a fake $HOME: symlink created, content readable.
- Only these 3 files are touched; pre-existing local edits to `.zshrc`/`.p10k.zsh`/`.gitignore_global` are deliberately not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)