### PR TITLE
feat: put ~/.local/bin on PATH

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -239,3 +239,9 @@ esac
 # peon-ping quick controls
 alias peon="bash $HOME/.claude/hooks/peon-ping/peon.sh"
 [ -f "$HOME/.claude/hooks/peon-ping/completions.bash" ] && source "$HOME/.claude/hooks/peon-ping/completions.bash"
+
+# Local user binaries (pipx, and the gwsa wrapper from the gws-multi-account skill)
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac


### PR DESCRIPTION
## Why

Tools that install per-user binaries into `~/.local/bin` were unreachable from a shell. Nothing in this repo (or in `/etc/paths`) ever added that directory to `PATH`, so a fresh terminal gave:

```
zsh: correct 'gwsa' to 'gws' [nyae]? n
zsh: command not found: gwsa
```

This surfaced while installing the `gwsa` wrapper from the `gws-multi-account` skill, which `install`s into `~/.local/bin`. It applies equally to `pipx` and anything else following the XDG user-bin convention.

The failure was easy to miss: the installer checked `$PATH` in its own process, which had inherited the directory from an unrepresentative parent environment, so it reported success while every new terminal window was broken.

## What

One guarded `PATH` prepend in `.zshrc`, using the same `case ":$PATH:"` idiom as the existing `pnpm` block, so re-sourcing `.zshrc` cannot produce duplicate entries.

## Verification

Tested in an interactive zsh started with only a stock system `PATH` (`env -i` plus `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`), i.e. what a fresh terminal actually gets:

- `command -v gwsa` → `/Users/herve/.local/bin/gwsa`
- `~/.local/bin` occurs in `$path` exactly **1** time
- after an explicit re-`source ~/.zshrc`, still exactly **1** time

## Note

`PATH` lives in `.zshrc` here rather than a `.zshenv`, matching every other entry in this repo (brew, bun, pnpm, anaconda). Consequence: non-interactive `zsh -c` invocations (cron, `launchd`, `ssh host cmd`) still won't see `~/.local/bin`. If that becomes a need, the fix is a new `.zshenv` — deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)